### PR TITLE
NO-JIRA: Updating odh-jupyter-trash-cleanup extension version to 0.1.1

### DIFF
--- a/odh-jupyter-trash-cleanup/package.json
+++ b/odh-jupyter-trash-cleanup/package.json
@@ -1,6 +1,6 @@
 {
     "name": "odh-jupyter-trash-cleanup",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "keywords": [
         "jupyter",
         "jupyterlab",


### PR DESCRIPTION
Updates the `odh-jupyter-trash-cleanup` to version 0.1.1