### PR TITLE
Add write permission for pr in odh-notebook-sync github action

### DIFF
--- a/.github/workflows/odh-notebooks-sync.yml
+++ b/.github/workflows/odh-notebooks-sync.yml
@@ -35,6 +35,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Clone repository and Sync
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add write permission for pr in odh-notebook-sync github action
Related-to: https://github.com/opendatahub-io/odh-ide-extensions/actions/runs/17945804071

The github action creates a Pull-request and the job steps requires these values to be passed to the workflow.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TBD

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to allow write access to repository contents and pull requests during automated runs.
  * Enables the workflow to commit changes and update PRs as part of synchronization tasks, improving automation reliability.
  * No changes to user-facing functionality or APIs.
  * Expect smoother maintenance operations with reduced manual intervention.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->