### PR TITLE
RHOAIENG-33059: Add integration tests for trash cleanup

### DIFF
--- a/odh-jupyter-trash-cleanup/.gitignore
+++ b/odh-jupyter-trash-cleanup/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 .yarn/
 
 .virtual_documents
+
+# Playwright
+.galata-root/

--- a/odh-jupyter-trash-cleanup/ui-tests/playwright.config.js
+++ b/odh-jupyter-trash-cleanup/ui-tests/playwright.config.js
@@ -2,6 +2,15 @@
  * Configuration for Playwright using default from @jupyterlab/galata
  */
 const baseConfig = require('@jupyterlab/galata/lib/playwright-config');
+const fs = require('fs');
+const path = require('path');
+
+// Test root for Jupyter server
+const GALATA_ROOT = path.resolve(__dirname, '..', '..', '.galata-root');
+try {
+  fs.rmSync(GALATA_ROOT, { recursive: true, force: true });
+} catch {}
+fs.mkdirSync(GALATA_ROOT, { recursive: true });
 
 module.exports = {
   ...baseConfig,
@@ -9,6 +18,10 @@ module.exports = {
     command: 'jlpm start',
     url: 'http://localhost:8888/lab',
     timeout: 120 * 1000,
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: !process.env.CI,
+    env: {
+      ...process.env,
+      JUPYTERLAB_GALATA_ROOT_DIR: GALATA_ROOT
+    }
   }
 };

--- a/odh-jupyter-trash-cleanup/ui-tests/tests/odh_jupyter_trash_cleanup.spec.ts
+++ b/odh-jupyter-trash-cleanup/ui-tests/tests/odh_jupyter_trash_cleanup.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@jupyterlab/galata';
+import * as fs from 'fs';
+import * as path from 'path';
 
 /**
  * Don't load JupyterLab webpage before running the tests.
@@ -20,4 +22,69 @@ test('should emit an activation console message', async ({ page }) => {
       s => s === 'JupyterLab extension odh-jupyter-trash-cleanup is activated!'
     )
   ).toHaveLength(1);
+});
+
+test('should have a button to empty trash', async ({ page }) => {
+  await page.goto();
+
+  const button = page.getByRole('button', { name: 'Empty Trash' });
+
+  expect(button).toBeVisible();
+});
+
+
+
+test('should empty the trash', async ({ page }) => {
+  await page.goto();
+
+
+  //Create a random text file and insert it into the trash
+  await page.getByRole('menuitem', { name: 'File' }).click();
+
+  const newRow = page.locator('li[data-type="submenu"]:has-text("New")');
+  await newRow.waitFor({ state: 'visible' });
+  await newRow.hover();
+  
+  await page.waitForSelector('ul.lm-Menu-content >> li:has-text("Text File")');
+  await page.getByRole('menuitem', { name: 'Text File' }).click();
+  
+  // regex here is used because there potentially could be more untitled.txt
+  const fileRow = page.locator('li.jp-DirListing-item span.jp-DirListing-itemText span', {
+    hasText: /^untitled.*\.txt$/
+  });
+  
+
+  // Delete the text file
+  await fileRow.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Delete' }).click();
+  await page.getByRole('button', { name: 'Delete' }).click();
+  await expect(fileRow).not.toBeVisible();
+
+
+  // Check if the file is in the trash? - is this the right approach?
+  const trashLocation = process.env.XDG_DATA_HOME
+    ? path.join(process.env.XDG_DATA_HOME, 'Trash', 'files')
+    : path.join(process.env.HOME || '', '.local/share/Trash/files');
+
+  if (!fs.existsSync(trashLocation)) {
+    throw new Error(`Trash folder not found: ${trashLocation}`);
+  } 
+  const files = fs.readdirSync(trashLocation);
+  expect(files.length).toBeGreaterThan(0);
+  
+
+  //Empty the trash
+  await page.getByRole('button', { name: 'Empty Trash' }).click();
+
+  const dialog = page.getByRole('dialog', { name: /empty all items from trash/i });
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByRole('button', { name: 'Empty Trash' }).click();
+  await expect(dialog).not.toBeVisible();
+
+
+  // Check if the trash is empty
+  const files2 = fs.readdirSync(trashLocation);
+  expect(files2.length).toBe(0);
+  
 });


### PR DESCRIPTION
PR for [RHOAIENG-33059](https://issues.redhat.com/browse/RHOAIENG-33059)

This PR adds two Galata tests:
1. just checks that the trash button is present
2. creates new file, deletes it, checks that it is in trash, presses empty trash button, checks that trash is empty

I had problem with Playwright configuration because it wasnt putting the deleted file to local trash bin but the trash button was recycling the local trash bin so I changed Playwright config to use local environment and new folder galata-root that is also added in gitignore (I am not sure that is the correct approach).

I tested this by running the tests and debuging the steps.