### PR TITLE
Add root tsconfig.json with strict mode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "target": "ES2018",
+    "skipLibCheck": true
+  },
+  "references": [
+    { "path": "./odh-jupyter-trash-cleanup" }
+  ],
+  "files": []
+}


### PR DESCRIPTION
## Summary

Adds a root-level TypeScript configuration file that enables strict type checking across the repository. This improves code quality tooling detection and helps AI agents understand function contracts through explicit type constraints.

Related-to: https://redhat.atlassian.net/browse/RHOAIENG-55762

## Changes

- Add `tsconfig.json` at the repository root with strict mode enabled
- Configure TypeScript project references to the `odh-jupyter-trash-cleanup` extension

## Configuration Details

```json
{
  "compilerOptions": {
    "strict": true,
    "strictNullChecks": true,
    "noImplicitAny": true
  },
  "references": [
    { "path": "./odh-jupyter-trash-cleanup" }
  ]
}
```

## Motivation

The extension already has strict mode enabled in its own `tsconfig.json`, but having a root-level configuration:
- Makes type safety settings discoverable at the repository root
- Enables IDE support for TypeScript across the entire monorepo
- Improves static analysis tool detection

## Test Plan

- [ ] Verify `tsc --build` works from root directory
- [ ] Confirm no breaking changes to existing TypeScript compilation

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation describing the monorepo structure, build system, extension patterns, development workflows, frontend-backend communication, and guidelines for contributing new extensions.
  * Added developer guidance documentation for code navigation and editor support.
  * Updated README with direct links to documentation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->