### PR TITLE
Add test fixtures for AI bug automation

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -1,0 +1,8 @@
+# Test Data
+
+This directory contains sample data for testing the ODH IDE extensions.
+
+## Files
+
+- `sample_trash_response.json` - Example successful trash empty response
+- `sample_error_response.json` - Example error response for testing error handling

--- a/testdata/api_responses/empty_result.json
+++ b/testdata/api_responses/empty_result.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "Trash was already empty",
+  "deleted": 0
+}

--- a/testdata/api_responses/error.json
+++ b/testdata/api_responses/error.json
@@ -1,0 +1,5 @@
+{
+  "success": false,
+  "message": "Failed to empty trash",
+  "error": "Permission denied"
+}

--- a/testdata/api_responses/success.json
+++ b/testdata/api_responses/success.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "Trash emptied successfully",
+  "deleted": 5
+}

--- a/testdata/empty_trash_state.json
+++ b/testdata/empty_trash_state.json
@@ -1,0 +1,5 @@
+{
+  "files": [],
+  "totalSize": 0,
+  "count": 0
+}

--- a/testdata/sample_error_response.json
+++ b/testdata/sample_error_response.json
@@ -1,0 +1,5 @@
+{
+  "success": false,
+  "message": "Permission denied: unable to access trash directory",
+  "error_code": "EACCES"
+}

--- a/testdata/sample_trash_files.json
+++ b/testdata/sample_trash_files.json
@@ -1,0 +1,21 @@
+{
+  "files": [
+    {
+      "name": "document.pdf",
+      "size": 1048576,
+      "deletedAt": "2024-01-15T10:30:00Z"
+    },
+    {
+      "name": "image.png",
+      "size": 524288,
+      "deletedAt": "2024-01-14T15:45:00Z"
+    },
+    {
+      "name": "notes.txt",
+      "size": 1024,
+      "deletedAt": "2024-01-13T09:00:00Z"
+    }
+  ],
+  "totalSize": 1573888,
+  "count": 3
+}

--- a/testdata/sample_trash_response.json
+++ b/testdata/sample_trash_response.json
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "message": "Trash emptied successfully",
+  "deleted_count": 5,
+  "freed_bytes": 1048576
+}


### PR DESCRIPTION
## Summary

Adds sample data files in a `testdata/` directory to help AI agents understand expected inputs and reproduce bugs.
Related-to: https://redhat.atlassian.net/browse/RHOAIENG-55762

## Changes

- Add `testdata/` directory with sample JSON files:
  - `sample_trash_response.json` - Example successful trash empty response
  - `sample_error_response.json` - Example error response
  - `sample_trash_files.json` - Example trash file listing
  - `empty_trash_state.json` - Example empty state
  - `api_responses/` - Additional API response examples
  - `README.md` - Documentation for the test data

## Motivation

Test fixtures help AI agents:
- Understand expected input/output formats
- Generate test cases with realistic data
- Reproduce bugs using sample data

## Test Plan

- [ ] Verify test data files are valid JSON
- [ ] No functional changes - documentation only

Made with [Cursor](https://cursor.com)