### PR TITLE
Add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ htmlcov/
 
 # virtual environments
 venv/
+.venv/


### PR DESCRIPTION
## Summary

Adds `.venv/` to `.gitignore` as an alternative virtual environment directory name.

Related-to: https://redhat.atlassian.net/browse/RHOAIENG-55762

## Changes

- Add `.venv/` entry to `.gitignore`

## Motivation

`.venv` is a common alternative to `venv` for Python virtual environment directories (following PEP 405 conventions). Adding it prevents accidental commits of local development environments.

## Test Plan

- [ ] No functional changes - gitignore update only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude additional Python virtual environment directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->